### PR TITLE
Auto-sync stale Towny accounts and repair UUID mismatches

### DIFF
--- a/Bukkit/src/net/tnemc/bukkit/BukkitCore.java
+++ b/Bukkit/src/net/tnemc/bukkit/BukkitCore.java
@@ -132,6 +132,7 @@ public class BukkitCore extends TNECore {
 
         PluginCore.log().debug("Adding Towny Account Types");
         TownyHandler.addTypes();
+        TownyHandler.synchronizeAccounts();
       }
 
       if(Bukkit.getPluginManager().getPlugin("Factions") != null) {

--- a/Bukkit/src/net/tnemc/bukkit/depend/towny/TownyCommand.java
+++ b/Bukkit/src/net/tnemc/bukkit/depend/towny/TownyCommand.java
@@ -19,28 +19,13 @@ package net.tnemc.bukkit.depend.towny;
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import com.palmergames.bukkit.towny.TownyAPI;
-import com.palmergames.bukkit.towny.TownySettings;
-import com.palmergames.bukkit.towny.object.Nation;
-import com.palmergames.bukkit.towny.object.Town;
-import net.tnemc.core.TNECore;
-import net.tnemc.core.account.Account;
-import net.tnemc.core.account.SharedAccount;
-import net.tnemc.core.account.holdings.HoldingsEntry;
 import net.tnemc.plugincore.PluginCore;
-import net.tnemc.plugincore.core.id.UUIDPair;
 import revxrsal.commands.annotation.Description;
 import revxrsal.commands.annotation.Subcommand;
 import revxrsal.commands.annotation.Usage;
 import revxrsal.commands.bukkit.actor.BukkitCommandActor;
 import revxrsal.commands.bukkit.annotation.CommandPermission;
 import revxrsal.commands.orphan.OrphanCommand;
-
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.UUID;
 
 /**
  * TownyCommand
@@ -57,70 +42,7 @@ public class TownyCommand implements OrphanCommand {
   public void command(final BukkitCommandActor sender) {
 
     PluginCore.log().inform("Updating Towny accounts...");
-    final Iterator<Map.Entry<UUID, UUIDPair>> idIterator = TNECore.eco().account().uuidProvider().pairs().entrySet().iterator();
-    while(idIterator.hasNext()) {
-
-      final Map.Entry<UUID, UUIDPair> entry = idIterator.next();
-      final String name = entry.getValue().getUsername();
-
-      PluginCore.log().inform("Updating account: " + name);
-
-      if(name.contains(TownySettings.getTownAccountPrefix())) {
-
-        final Town town = TownyAPI.getInstance().getTown(name.replace(TownySettings.getTownAccountPrefix(), ""));
-        if(town == null) {
-          //delete account
-          TNECore.eco().account().deleteAccount(entry.getKey());
-          continue;
-        }
-
-        final UUID townyUUID = town.getUUID();
-        final Optional<Account> account = TNECore.eco().account().findAccount(entry.getKey().toString());
-        if(!townyUUID.equals(entry.getKey()) && account.isPresent()) {
-
-          final List<HoldingsEntry> holdings = account.get().getWallet().entryList();
-
-          idIterator.remove();
-          TNECore.eco().account().deleteAccount(entry.getKey());
-
-          final Optional<SharedAccount> response = TNECore.eco().account().createNonPlayerAccount(townyUUID.toString(), name);
-          if(response.isPresent()) {
-
-            for(final HoldingsEntry entry1 : holdings) {
-
-              response.get().setHoldings(entry1);
-            }
-          }
-        }
-      } else if(entry.getValue().getUsername().contains(TownySettings.getNationAccountPrefix())) {
-
-        final Nation nation = TownyAPI.getInstance().getNation(name.replace(TownySettings.getNationAccountPrefix(), ""));
-        if(nation == null) {
-          //delete account
-          TNECore.eco().account().deleteAccount(entry.getKey());
-          continue;
-        }
-
-        final UUID townyUUID = nation.getUUID();
-        final Optional<Account> account = TNECore.eco().account().findAccount(entry.getKey().toString());
-        if(!townyUUID.equals(entry.getKey()) && account.isPresent()) {
-
-          final List<HoldingsEntry> holdings = account.get().getWallet().entryList();
-
-          idIterator.remove();
-          TNECore.eco().account().deleteAccount(entry.getKey());
-
-          final Optional<SharedAccount> response = TNECore.eco().account().createNonPlayerAccount(townyUUID.toString(), name);
-          if(response.isPresent()) {
-
-            for(final HoldingsEntry entry1 : holdings) {
-
-              response.get().setHoldings(entry1);
-            }
-          }
-        }
-      }
-    }
+    TownyHandler.synchronizeAccounts();
 
     PluginCore.log().inform("Finished updating Towny accounts!");
   }

--- a/PaperCore/src/net/tnemc/paper/PaperCore.java
+++ b/PaperCore/src/net/tnemc/paper/PaperCore.java
@@ -129,6 +129,7 @@ public class PaperCore extends TNECore {
 
         PluginCore.log().debug("Adding Towny Account Types");
         TownyHandler.addTypes();
+        TownyHandler.synchronizeAccounts();
       }
 
       if(Bukkit.getPluginManager().getPlugin("Factions") != null) {


### PR DESCRIPTION
### Motivation
- Prevent stale Towny `town`/`nation` accounts remaining in the TNE database from conflicting with newly created Towny entities of the same name and causing balance resets on restart.
- Centralize and reuse the existing reconciliation logic so startup and the admin command both clean stale entries and repair UUID mismatches automatically.

### Description
- Introduced `TownyHandler.synchronizeAccounts()` which iterates account UUID pairs, removes accounts whose Towny entity no longer exists, and for UUID mismatches re-creates the non-player account using the current Towny UUID while preserving holdings (implemented in `Bukkit/src/net/tnemc/bukkit/depend/towny/TownyHandler.java`).
- Replaced duplicated reconciliation code in the admin `tne towny` commands with a call to `TownyHandler.synchronizeAccounts()` for both Bukkit and Paper (updated `Bukkit/src/net/tnemc/bukkit/depend/towny/TownyCommand.java` and `PaperCore/src/net/tnemc/paper/hook/towny/TownyCommand.java`).
- Wired automatic synchronization into the account-type registration callback so reconciliation runs during startup for both Bukkit and Paper cores (updated `Bukkit/src/net/tnemc/bukkit/BukkitCore.java` and `PaperCore/src/net/tnemc/paper/PaperCore.java`).
- Added informative logging when removing stale accounts or repairing UUID mismatches and preserved existing holdings when migrating accounts to the new UUID.

### Testing
- Attempted to compile the modified modules with `mvn -pl Bukkit,PaperCore -DskipTests compile` which failed due to an external Maven plugin resolution error (repository returned `403 Forbidden` for `maven-resources-plugin:3.3.1`).
- No automated unit tests were run in this environment because the build could not complete due to the dependency resolution issue.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e27c09fb88320896aa3374b65d74a)