### PR TITLE
Add shulker-box overflow support for item currency payouts

### DIFF
--- a/Core/resources/messages.yml
+++ b/Core/resources/messages.yml
@@ -121,6 +121,7 @@ Messages:
     RequestSender: "<green>You have sent a request to <white>$player <green> for $amount."
     Request: "<white>You have received a money request from <green>$player<white> for <gold>$amount<white>! <click:run_command:/money pay $player $amount $currency><green><underlined>Click to send them the funds!</click>"
     EnderChest: "<red>Some funds were put in your ender chest because your inventory was full!"
+    ShulkerBox: "<red>Some funds were put in a shulker box in your inventory because your inventory was full!"
     Dropped: "<red>Some funds were dropped on the ground because your inventory was full!"
 
   #Messages.Menu.


### PR DESCRIPTION
### Motivation

- Improve item-currency payout behavior so when players are given items and their inventory is full we attempt to place overflow into shulker boxes in their inventory before dropping to the ground. 
- Mirror the existing ender-chest fill behavior and notify players when currency is placed into a shulker box instead of dropped. 
- Implement this using existing API calls and helper methods without reflection for clarity and maintainability.

### Description

- Updated `CalculationData.provideMaterials` to attempt a shulker-box insertion pass by calling a new `tryShulkerOverflow` helper after the direct inventory insertion and again after the ender-chest insertion when `enderFill` is enabled. 
- Added `tryShulkerOverflow` which re-runs `PluginCore.server().calculations().giveItems(...)` with `shulker=true` and notifies the player with `Messages.Money.ShulkerBox` when shulker placement succeeds. 
- Replaced single-stack leftover accounting with `getLeftoverAmount` which sums leftover amounts across all stacks to ensure wallet counts are adjusted correctly. 
- Added the `ShulkerBox` message key to `Core/resources/messages.yml` and preserved the existing fallback ordering (`inventory` -> optional `shulker` -> optional `ender chest` -> optional `shulker` -> `ground`) and existing API usage (`giveItems`, `drop`, etc.).

### Testing

- Attempted to compile the Core module with `mvn -pl Core -DskipTests compile`, but the build could not complete in this environment because remote plugin resolution failed for `maven-resources-plugin:3.1.0` (HTTP 403). 
- No automated tests were executed here due to the compile environment failure. 
- Changes were validated by source inspection and local file updates to `Core/src/net/tnemc/core/currency/calculations/CalculationData.java` and `Core/resources/messages.yml` to ensure correct integration points and messaging.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69951d7c5d548320aa162da41cccca52)