### PR TITLE
Fix startup and shutdown stalls in core persistence

### DIFF
--- a/Core/src/net/tnemc/core/TNECore.java
+++ b/Core/src/net/tnemc/core/TNECore.java
@@ -418,19 +418,20 @@ public abstract class TNECore extends PluginEngine {
   public void registerUpdateChecker() {
 
     if(MainConfig.yaml().getBoolean("Core.Update.Check")) {
-      this.updateChecker = new Updater();
-
       PluginCore.log().inform("Running version: " + version() + " Build: " + build());
+      PluginCore.log().inform("Build Stability: " + Updater.stability(version(), build()));
 
-      PluginCore.log().inform("Build Stability: " + this.updateChecker.stable());
+      PluginCore.server().scheduler().createDelayedTask(()->{
+        this.updateChecker = new Updater();
 
-      if(this.updateChecker.needsUpdate()) {
-        PluginCore.log().inform("Update Available! Latest: " + this.updateChecker.getBuild());
-      }
+        if(this.updateChecker.needsUpdate()) {
+          PluginCore.log().inform("Update Available! Latest: " + this.updateChecker.getBuild());
+        }
 
-      if(this.updateChecker.isEarlyBuild()) {
-        PluginCore.log().inform("Running pre-release version! Thanks for being a tester!");
-      }
+        if(this.updateChecker.isEarlyBuild()) {
+          PluginCore.log().inform("Running pre-release version! Thanks for being a tester!");
+        }
+      }, new ChoreTime(0), ChoreExecution.SECONDARY);
     }
   }
 
@@ -560,10 +561,11 @@ public abstract class TNECore extends PluginEngine {
       return;
     }
 
-    final Optional<Datable<?>> data = Optional.ofNullable(storage.getEngine().datables().get(Account.class));
-    if(data.isPresent()) {
-      data.get().storeAll(storage.getConnector(), null);
-    }
+    final Optional<Datable<?>> accountData = Optional.ofNullable(storage.getEngine().datables().get(Account.class));
+    accountData.ifPresent(datable->datable.storeAll(storage.getConnector(), null));
+
+    final Optional<Datable<?>> receiptData = Optional.ofNullable(storage.getEngine().datables().get(Receipt.class));
+    receiptData.ifPresent(datable->datable.storeAll(storage.getConnector(), null));
   }
 
   public MainConfig config() {

--- a/Core/src/net/tnemc/core/account/Account.java
+++ b/Core/src/net/tnemc/core/account/Account.java
@@ -52,6 +52,7 @@ public class Account extends ReceiptBox {
   protected String name;
   protected long creationDate;
   protected String pin;
+  protected volatile boolean dirty = true;
 
   protected Wallet wallet;
 
@@ -274,6 +275,7 @@ public class Account extends ReceiptBox {
   public void setName(final String name) {
 
     this.name = name;
+    markDirty();
   }
 
   public long getCreationDate() {
@@ -284,6 +286,7 @@ public class Account extends ReceiptBox {
   public void setCreationDate(final long creationDate) {
 
     this.creationDate = creationDate;
+    markDirty();
   }
 
   public String getPin() {
@@ -294,6 +297,7 @@ public class Account extends ReceiptBox {
   public void setPin(final String pin) {
 
     this.pin = pin;
+    markDirty();
   }
 
   public AccountStatus getStatus() {
@@ -304,6 +308,7 @@ public class Account extends ReceiptBox {
   public void setStatus(final AccountStatus status) {
 
     this.status = status;
+    markDirty();
   }
 
   public Wallet getWallet() {
@@ -314,5 +319,24 @@ public class Account extends ReceiptBox {
   public void setWallet(final Wallet wallet) {
 
     this.wallet = wallet;
+    markDirty();
+  }
+
+  public boolean isDirty() {
+
+    return dirty || (wallet != null && wallet.isDirty());
+  }
+
+  public void markDirty() {
+
+    this.dirty = true;
+  }
+
+  public void clearDirty() {
+
+    this.dirty = false;
+    if(wallet != null) {
+      wallet.clearDirty();
+    }
   }
 }

--- a/Core/src/net/tnemc/core/account/PlayerAccount.java
+++ b/Core/src/net/tnemc/core/account/PlayerAccount.java
@@ -116,6 +116,7 @@ public class PlayerAccount extends Account {
   public void setLastOnline(final long lastOnline) {
 
     this.lastOnline = lastOnline;
+    markDirty();
   }
 
   public String getLanguage() {
@@ -126,5 +127,6 @@ public class PlayerAccount extends Account {
   public void setLanguage(final String language) {
 
     this.language = language;
+    markDirty();
   }
 }

--- a/Core/src/net/tnemc/core/account/SharedAccount.java
+++ b/Core/src/net/tnemc/core/account/SharedAccount.java
@@ -85,6 +85,7 @@ public class SharedAccount extends Account {
     final Member member = members.getOrDefault(identifier, new Member(identifier));
     member.addPermission(permission, value);
     members.put(identifier, member);
+    markDirty();
   }
 
   /**
@@ -99,6 +100,7 @@ public class SharedAccount extends Account {
     final Member member = members.getOrDefault(identifier, new Member(identifier));
     member.addPermission(permission, value);
     members.put(identifier, member);
+    markDirty();
   }
 
   /**
@@ -109,7 +111,10 @@ public class SharedAccount extends Account {
    */
   public void removePermission(final UUID identifier, final Permission permission) {
 
-    findMember(identifier).ifPresent(mem->mem.removePermission(permission));
+    findMember(identifier).ifPresent(mem->{
+      mem.removePermission(permission);
+      markDirty();
+    });
   }
 
   /**
@@ -120,7 +125,10 @@ public class SharedAccount extends Account {
    */
   public void removePermission(final UUID identifier, final String permission) {
 
-    findMember(identifier).ifPresent(mem->mem.removePermission(permission));
+    findMember(identifier).ifPresent(mem->{
+      mem.removePermission(permission);
+      markDirty();
+    });
   }
 
   /**
@@ -178,5 +186,6 @@ public class SharedAccount extends Account {
   public void setOwner(final UUID owner) {
 
     this.owner = owner;
+    markDirty();
   }
 }

--- a/Core/src/net/tnemc/core/account/holdings/Wallet.java
+++ b/Core/src/net/tnemc/core/account/holdings/Wallet.java
@@ -39,6 +39,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public class Wallet {
 
   private final Map<String, RegionHoldings> holdings = new ConcurrentHashMap<>();
+  private volatile boolean dirty = true;
 
   /**
    * Used to get the holdings based on specific specifications, or returns an empty optional if no
@@ -152,6 +153,7 @@ public class Wallet {
   public void deleteHoldings(final @NotNull String region) {
 
     holdings.remove(region);
+    dirty = true;
   }
 
   /**
@@ -164,6 +166,7 @@ public class Wallet {
 
     if(holdings.containsKey(region)) {
       holdings.get(region).getHoldings().remove(currency);
+      dirty = true;
     }
   }
 
@@ -180,6 +183,7 @@ public class Wallet {
 
     if(holdings.containsKey(region) && holdings.get(region).getHoldings().containsKey(currency)) {
       holdings.get(region).getHoldings().get(currency).getHoldings().remove(type.asID());
+      dirty = true;
     }
   }
 
@@ -187,6 +191,7 @@ public class Wallet {
   public void deleteAllHoldings() {
 
     holdings.clear();
+    dirty = true;
   }
 
   /**
@@ -264,5 +269,16 @@ public class Wallet {
     regionHoldings.setHoldingsEntry(entry, entry.getHandler());
 
     holdings.put(entry.getRegion(), regionHoldings);
+    dirty = true;
+  }
+
+  public boolean isDirty() {
+
+    return dirty;
+  }
+
+  public void clearDirty() {
+
+    dirty = false;
   }
 }

--- a/Core/src/net/tnemc/core/io/serialization/impl/SerialAccount.java
+++ b/Core/src/net/tnemc/core/io/serialization/impl/SerialAccount.java
@@ -107,7 +107,8 @@ public class SerialAccount implements JSONAble<Account> {
       final AccountAPIResponse response = TNECore.eco().account().createAccount(identifier,
                                                                                 name,
                                                                                 !(type.equalsIgnoreCase("player") ||
-                                                                                  type.equalsIgnoreCase("bedrock")));
+                                                                                  type.equalsIgnoreCase("bedrock")),
+                                                                                true);
       if(response.getResponse().success()) {
 
         final Optional<Account> account = response.getAccount();
@@ -149,6 +150,7 @@ public class SerialAccount implements JSONAble<Account> {
             player.setLastOnline((Long)json.get("lastOnline"));
             player.setLanguage((String)json.get("language"));
           }
+          account.get().clearDirty();
           return account.get();
         }
       }

--- a/Core/src/net/tnemc/core/io/storage/datables/sql/standard/SQLAccount.java
+++ b/Core/src/net/tnemc/core/io/storage/datables/sql/standard/SQLAccount.java
@@ -163,10 +163,11 @@ public class SQLAccount implements Datable<Account> {
         }
       }
 
+      TNECore.instance().storage().storeAll(account.getIdentifier().toString());
+      account.clearDirty();
+
       final AccountSaveCallback callback = new AccountSaveCallback(account);
       PluginCore.callbacks().call(callback);
-
-      TNECore.instance().storage().storeAll(account.getIdentifier().toString());
     }
   }
 
@@ -264,7 +265,9 @@ public class SQLAccount implements Datable<Account> {
 
     if(connector instanceof SQLConnector) {
       for(final Account account : TNECore.eco().account().getAccounts().values()) {
-        store(connector, account, account.getIdentifier().toString());
+        if(account.isDirty()) {
+          store(connector, account, account.getIdentifier().toString());
+        }
       }
     }
   }
@@ -309,7 +312,8 @@ public class SQLAccount implements Datable<Account> {
           final AccountAPIResponse response = TNECore.eco().account().createAccount(identifier,
                                                                                     result.getString("username"),
                                                                                     !(type.equalsIgnoreCase("player") ||
-                                                                                      type.equalsIgnoreCase("bedrock")));
+                                                                                      type.equalsIgnoreCase("bedrock")),
+                                                                                    true);
           if(response.getResponse().success()) {
 
             //load our basic account information
@@ -377,6 +381,8 @@ public class SQLAccount implements Datable<Account> {
         for(final HoldingsEntry entry : holdings) {
           account.getWallet().setHoldings(entry);
         }
+
+        account.clearDirty();
 
         final AccountLoadCallback callback = new AccountLoadCallback(account);
         PluginCore.callbacks().call(callback);

--- a/Core/src/net/tnemc/core/io/storage/datables/sql/standard/SQLReceipt.java
+++ b/Core/src/net/tnemc/core/io/storage/datables/sql/standard/SQLReceipt.java
@@ -102,6 +102,7 @@ public class SQLReceipt implements Datable<Receipt> {
 
       storeParticipant(connector, receipt.getFrom(), receipt.getModifierFrom(), "from", receipt.getId().toString());
       storeParticipant(connector, receipt.getTo(), receipt.getModifierTo(), "to", receipt.getId().toString());
+      receipt.clearDirty();
     }
   }
 
@@ -172,7 +173,9 @@ public class SQLReceipt implements Datable<Receipt> {
     if(connector instanceof SQLConnector) {
 
       for(final Receipt receipt : TransactionManager.receipts().getReceipts().values()) {
-        store(connector, receipt, identifier);
+        if(receipt.isDirty()) {
+          store(connector, receipt, identifier);
+        }
       }
     }
   }
@@ -218,6 +221,7 @@ public class SQLReceipt implements Datable<Receipt> {
     receipt.setSource(ActionSource.create(result.getString("receipt_source"), result.getString("receipt_source_type")));
     receipt.setArchive(result.getBoolean("archive"));
     receipt.setVoided(result.getBoolean("voided"));
+    receipt.clearDirty();
 
     return receipt;
   }

--- a/Core/src/net/tnemc/core/io/storage/datables/yaml/YAMLAccount.java
+++ b/Core/src/net/tnemc/core/io/storage/datables/yaml/YAMLAccount.java
@@ -150,10 +150,6 @@ public class YAMLAccount implements Datable<Account> {
     try {
 
       yaml.save();
-
-      final AccountSaveCallback callback = new AccountSaveCallback(account);
-      PluginCore.callbacks().call(callback);
-
       yaml = null;
     } catch(final IOException ignore) {
       PluginCore.log().error("Issue saving account file. Account: " + account.getName());
@@ -162,6 +158,10 @@ public class YAMLAccount implements Datable<Account> {
     TNECore.yaml().remove(file);
 
     TNECore.instance().storage().storeAll(account.getIdentifier().toString());
+    account.clearDirty();
+
+    final AccountSaveCallback callback = new AccountSaveCallback(account);
+    PluginCore.callbacks().call(callback);
   }
 
   /**
@@ -173,7 +173,9 @@ public class YAMLAccount implements Datable<Account> {
   public void storeAll(final StorageConnector<?> connector, @Nullable final String identifier) {
 
     for(final Account account : TNECore.eco().account().getAccounts().values()) {
-      store(connector, account, account.getIdentifier().toString());
+      if(account.isDirty()) {
+        store(connector, account, account.getIdentifier().toString());
+      }
     }
   }
 
@@ -239,7 +241,8 @@ public class YAMLAccount implements Datable<Account> {
           final AccountAPIResponse response = TNECore.eco().account().createAccount(identifier,
                                                                                     yaml.getString("Info.Name"),
                                                                                     !(type.equalsIgnoreCase("player") ||
-                                                                                      type.equalsIgnoreCase("bedrock")));
+                                                                                      type.equalsIgnoreCase("bedrock")),
+                                                                                    true);
           if(response.getResponse().success() && response.getAccount().isPresent()) {
 
             //load our basic account information
@@ -276,6 +279,8 @@ public class YAMLAccount implements Datable<Account> {
             for(final HoldingsEntry entry : holdings) {
               account.getWallet().setHoldings(entry);
             }
+
+            account.clearDirty();
 
             final AccountLoadCallback callback = new AccountLoadCallback(account);
             PluginCore.callbacks().call(callback);

--- a/Core/src/net/tnemc/core/io/storage/datables/yaml/YAMLReceipt.java
+++ b/Core/src/net/tnemc/core/io/storage/datables/yaml/YAMLReceipt.java
@@ -168,6 +168,7 @@ public class YAMLReceipt implements Datable<Receipt> {
       return;
     }
     TNECore.yaml().remove(fileSrc);
+    receipt.clearDirty();
   }
 
   /**
@@ -181,7 +182,9 @@ public class YAMLReceipt implements Datable<Receipt> {
   public void storeAll(final StorageConnector<?> connector, @Nullable final String identifier) {
 
     for(final Receipt receipt : TransactionManager.receipts().getReceipts().values()) {
-      store(connector, receipt, identifier);
+      if(receipt.isDirty()) {
+        store(connector, receipt, identifier);
+      }
     }
   }
 
@@ -240,6 +243,7 @@ public class YAMLReceipt implements Datable<Receipt> {
 
           receipt.setArchive(yaml.getBoolean("archive"));
           receipt.setVoided(yaml.getBoolean("voided"));
+          receipt.clearDirty();
 
           return Optional.of(receipt);
         } else {

--- a/Core/src/net/tnemc/core/manager/Updater.java
+++ b/Core/src/net/tnemc/core/manager/Updater.java
@@ -57,7 +57,12 @@ public class Updater extends UpdateChecker {
   @Override
   public String stable() {
 
-    if(new Semver(PluginCore.engine().version() + "-" + PluginCore.engine().build(), Semver.SemverType.LOOSE).isStable()) {
+    return stability(PluginCore.engine().version(), PluginCore.engine().build());
+  }
+
+  public static String stability(final String version, final String build) {
+
+    if(new Semver(version + "-" + build, Semver.SemverType.LOOSE).isStable()) {
       return "Stable";
     }
     return "Not Stable";

--- a/Core/src/net/tnemc/core/transaction/Receipt.java
+++ b/Core/src/net/tnemc/core/transaction/Receipt.java
@@ -49,6 +49,7 @@ public class Receipt {
   //Our active information that may be modified.
   private boolean archive = false;
   private boolean voided = false;
+  private volatile boolean dirty = true;
 
   public Receipt(final UUID id, final long time, final String type) {
 
@@ -99,7 +100,7 @@ public class Receipt {
     try {
       transaction.process((transactionResult->{
         if(transactionResult.isSuccessful()) {
-          this.voided = true;
+          setVoided(true);
         }
       }));
     } catch(InvalidTransactionException e) {
@@ -131,6 +132,7 @@ public class Receipt {
   public void setSource(final ActionSource source) {
 
     this.source = source;
+    markDirty();
   }
 
   public TransactionParticipant getFrom() {
@@ -141,6 +143,7 @@ public class Receipt {
   public void setFrom(final TransactionParticipant from) {
 
     this.from = from;
+    markDirty();
   }
 
   public TransactionParticipant getTo() {
@@ -151,6 +154,7 @@ public class Receipt {
   public void setTo(final TransactionParticipant to) {
 
     this.to = to;
+    markDirty();
   }
 
   public HoldingsModifier getModifierTo() {
@@ -161,6 +165,7 @@ public class Receipt {
   public void setModifierTo(final HoldingsModifier modifierTo) {
 
     this.modifierTo = modifierTo;
+    markDirty();
   }
 
   public HoldingsModifier getModifierFrom() {
@@ -171,6 +176,7 @@ public class Receipt {
   public void setModifierFrom(final HoldingsModifier modifierFrom) {
 
     this.modifierFrom = modifierFrom;
+    markDirty();
   }
 
   public boolean isArchive() {
@@ -181,6 +187,7 @@ public class Receipt {
   public void setArchive(final boolean archive) {
 
     this.archive = archive;
+    markDirty();
   }
 
   public boolean isVoided() {
@@ -191,5 +198,21 @@ public class Receipt {
   public void setVoided(final boolean voided) {
 
     this.voided = voided;
+    markDirty();
+  }
+
+  public boolean isDirty() {
+
+    return dirty;
+  }
+
+  public void markDirty() {
+
+    this.dirty = true;
+  }
+
+  public void clearDirty() {
+
+    this.dirty = false;
   }
 }


### PR DESCRIPTION
Move the update check off the server thread so startup no longer waits on the remote update server.

Prevent account load and deserialization paths from re-saving existing data while it is being loaded, which was causing unnecessary write churn during enable.

Track dirty state for accounts, wallets, and receipts so autosave and disable-time flushes only persist modified objects while still forcing a final synchronous flush on shutdown.

Verified with /opt/idea-iu/plugins/maven/lib/maven3/bin/mvn -q -pl Core -am test-compile.